### PR TITLE
Migrate plugin to Gradle v9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ java {
 	targetCompatibility = JavaVersion.VERSION_17
 }
 
-version = "3.0.0"
+version = "2.19.0"
 group = "com.webcohesion.enunciate"
 
 gradlePlugin {

--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,12 @@ dependencies {
 	implementation "com.webcohesion.enunciate:enunciate-top:2.18.0"
 }
 
-sourceCompatibility = "17"
-targetCompatibility = "17"
+java {
+	sourceCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
+}
 
-version = "2.18.0"
+version = "3.0.0"
 group = "com.webcohesion.enunciate"
 
 gradlePlugin {

--- a/src/main/java/com/webcohesion/enunciate/gradle/EnunciatePlugin.java
+++ b/src/main/java/com/webcohesion/enunciate/gradle/EnunciatePlugin.java
@@ -38,7 +38,7 @@ public class EnunciatePlugin implements Plugin<Project> {
 
 		Configuration configuration = project.getConfigurations().maybeCreate("enunciate");
 		
-		EnunciateTask task = project.getTasks().create("enunciate", EnunciateTask.class);
+		EnunciateTask task = project.getTasks().register("enunciate", EnunciateTask.class).get();
 		task.setEnunciateModuleConfig(configuration);
 	}
 }


### PR DESCRIPTION
## Purpose
Gradle 9 has just been released but the plugin is not compatible with it. This PR migrates the plugin to Gradle 9. 

Closes #32
Closes #34 

## Changes
-  Replace JavaPluginConvention by JavaPluginExtension
- Fix typo in logged message when enunciate config file is not found

## Tests
Published to local maven and verified generated documents for a simple JAX-RS endpoint. @stoicflame @jskov-jyskebank-dk could you test on your side as well, please?